### PR TITLE
Remove redundant code

### DIFF
--- a/src/components/falcorGet.js
+++ b/src/components/falcorGet.js
@@ -68,7 +68,7 @@ function createHandler(getPathSets, mergeProps) {
           if (!hasResponse) {
             setState({
               loading: false,
-              response: NO_RESPONSE,
+              response: {},
             })
           }
         },

--- a/src/components/falcorGet.js
+++ b/src/components/falcorGet.js
@@ -8,12 +8,7 @@ const defaultState = {
   response: null,
 }
 
-const NO_RESPONSE = {}
-
 export function defaultMergeProps(response, ownProps) {
-  if (response === NO_RESPONSE) {
-    return null
-  }
   const { json } = response || {}
   return {
     ...ownProps,


### PR DESCRIPTION
Since `{} === {}` returns false, that if statement will never run unless the actual `NO_RESPONSE` variable is passed in. Also removed the `NO_RESPONSE` further down just as I was deleting it, but if you like it like that I can keep that and just remove the if statement